### PR TITLE
Send notes field in issue

### DIFF
--- a/net.sf.redmine_mylyn.api/src/net/sf/redmine_mylyn/api/client/RedmineApiIssueProperty.java
+++ b/net.sf.redmine_mylyn.api/src/net/sf/redmine_mylyn/api/client/RedmineApiIssueProperty.java
@@ -10,7 +10,7 @@ import net.sf.redmine_mylyn.api.model.Issue;
 import net.sf.redmine_mylyn.internal.api.Messages;
 
 public enum RedmineApiIssueProperty {
-	SUBJECT, DESCRIPTION, ASSIGNED_TO, CATEGORY, DONE_RATIO, DUE_DATE, ESTIMATED_HOURS, FIXED_VERSION, PARENT("parent_issue_id"), PRIORITY, PROJECT, START_DATE, STATUS, TRACKER; //$NON-NLS-1$
+	SUBJECT, DESCRIPTION, ASSIGNED_TO, CATEGORY, DONE_RATIO, DUE_DATE, ESTIMATED_HOURS, FIXED_VERSION, PARENT("parent_issue_id"), PRIORITY, PROJECT, START_DATE, STATUS, TRACKER, NOTES; //$NON-NLS-1$
 	
 	private static SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd");
 	

--- a/net.sf.redmine_mylyn.api/src/net/sf/redmine_mylyn/api/model/Issue.java
+++ b/net.sf.redmine_mylyn.api/src/net/sf/redmine_mylyn/api/model/Issue.java
@@ -91,6 +91,9 @@ public class Issue implements IModel {
 	@IssuePropertyMapping(RedmineApiIssueProperty.PARENT)
 	private int parentId;
 
+	@IssuePropertyMapping(RedmineApiIssueProperty.NOTES)
+	private String notes;
+	
 	@XmlList
 	private int [] subtasks;
 
@@ -372,5 +375,13 @@ public class Issue implements IModel {
 	
 	public void setClosed(boolean closed) {
 		this.closed = closed;
+	}
+	
+	public String getNotes() {
+		return notes;
+	}
+	
+	public void setNotes(String notes) {
+		this.notes = notes;
 	}
 }

--- a/net.sf.redmine_mylyn.api/src/net/sf/redmine_mylyn/internal/api/client/Api_2_7_ClientImpl.java
+++ b/net.sf.redmine_mylyn.api/src/net/sf/redmine_mylyn/internal/api/client/Api_2_7_ClientImpl.java
@@ -299,6 +299,7 @@ public class Api_2_7_ClientImpl extends AbstractClient {
 		monitor.beginTask(Messages.PROGRESS_UPLOAD_TASK, 1);
 
 		try {
+			issueValues.put(RedmineApiIssueProperty.NOTES, comment);
 			updateIssue(issueId, new IssueRequestEntity(issueValues, comment, timeEntry), errorCollector, monitor);
 		} catch (UnsupportedEncodingException e) {
 			throw new RedmineApiErrorException(Messages.ERRMSG_METHOD_EXECUTION_FAILED_INVALID_ENCODING, e, "UTF-8"); //$NON-NLS-2$ //$NON-NLS-1$
@@ -317,6 +318,7 @@ public class Api_2_7_ClientImpl extends AbstractClient {
 		monitor.beginTask(Messages.PROGRESS_UPLOAD_TASK, 1);
 
 		try {
+			issue.setNotes(comment);
 			updateIssue(issue.getId(), new IssueRequestEntity(issue, comment, timeEntry), errorCollector, monitor);
 		} catch (UnsupportedEncodingException e) {
 			throw new RedmineApiErrorException(Messages.ERRMSG_METHOD_EXECUTION_FAILED_INVALID_ENCODING, e, "UTF-8"); //$NON-NLS-2$ //$NON-NLS-1$


### PR DESCRIPTION
This patch adds the notes field to the issue object in issue update calls.

This is because the API in the 2.2.x series Redmine instance I am using no longer seems to accept the notes parameter at the request level - notes are not updated on the server issue.

Still sends notes field as separate parameter as well - for now this breaks nothing.
