### PR TITLE
Fix Open With Browser action.

### DIFF
--- a/net.sf.redmine_mylyn.core-test/src/net/sf/redmine_mylyn/internal/core/IssueMapperTest.java
+++ b/net.sf.redmine_mylyn.core-test/src/net/sf/redmine_mylyn/internal/core/IssueMapperTest.java
@@ -123,7 +123,7 @@ public class IssueMapperTest {
 		assertEquals(""+journal.getUserId(), attribute.getAttribute(TaskAttribute.COMMENT_AUTHOR).getValue());
 		assertEquals(""+journal.getCreatedOn().getTime(), attribute.getAttribute(TaskAttribute.COMMENT_DATE).getValue());
 		assertEquals(""+journal.getNotes(), attribute.getAttribute(TaskAttribute.COMMENT_TEXT).getValue());
-		assertEquals(URL + "/issues/show/" + issue.getId() + "#note-3", attribute.getAttribute(TaskAttribute.COMMENT_URL).getValue());
+		assertEquals(URL + "/issues/" + issue.getId() + "#note-3", attribute.getAttribute(TaskAttribute.COMMENT_URL).getValue());
 		
 		/* Attachments */
 		/* affected by TaskAttributeMapper, RedmineTaskAttributeMapper */

--- a/net.sf.redmine_mylyn.core/src/net/sf/redmine_mylyn/core/IRedmineConstants.java
+++ b/net.sf.redmine_mylyn.core/src/net/sf/redmine_mylyn/core/IRedmineConstants.java
@@ -2,7 +2,7 @@ package net.sf.redmine_mylyn.core;
 
 public interface IRedmineConstants {
 
-	public final static String REDMINE_URL_TICKET = "/issues/show/"; //$NON-NLS-1$
+	public final static String REDMINE_URL_TICKET = "/issues/"; //$NON-NLS-1$
 	public final static String REDMINE_URL_PART_COMMENT = "#note-%d"; //$NON-NLS-1$
 	public final static String REDMINE_URL_ATTACHMENT_DOWNLOAD = "%s/attachments/download/%d"; //$NON-NLS-1$
 


### PR DESCRIPTION
Originally the Mylyn action to open a task with the Browser was failing
because the constant used to compose the HTTP URL was wrong
("/issues/show/"). Now the value is correct ("/issues/") and the Mylyn
action works as expected.
