### PR TITLE
Add newer versions of Eclipse to the profile list.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -119,7 +119,6 @@
 		<profile>
 			<id>platform-indigo</id>
 			<activation>
-				<activeByDefault>true</activeByDefault>
 				<property>
 					<name>platform-version-name</name>
 					<value>indigo</value>
@@ -128,6 +127,32 @@
 			<properties>
 				<eclipse-site>http://download.eclipse.org/releases/indigo</eclipse-site>
 				<platform-version>[3.7,3.8)</platform-version>
+			</properties>
+		</profile>
+		<profile>
+			<id>platform-juno</id>
+			<activation>
+				<property>
+					<name>platform-version-name</name>
+					<value>juno</value>
+				</property>
+			</activation>
+			<properties>
+				<eclipse-site>http://download.eclipse.org/releases/juno</eclipse-site>
+				<platform-version>[3.8,4.3)</platform-version>
+			</properties>
+		</profile>
+		<profile>
+			<id>platform-kepler</id>
+			<activation>
+				<property>
+					<name>platform-version-name</name>
+					<value>kepler</value>
+				</property>
+			</activation>
+			<properties>
+				<eclipse-site>http://download.eclipse.org/releases/kepler</eclipse-site>
+				<platform-version>[4.3,4.4)</platform-version>
 			</properties>
 		</profile>
 	</profiles>


### PR DESCRIPTION
Had some trouble installing the connector on Kepler because of
dependencies (like json 1.0.0 and some of the logging parts)
Adding these, making Indigo non-default, and changing the
platform-version-name property to "kepler" produced a build
that was happy to install.

Perhaps combining this with newer Orbit drops for the profiles
on newer versions may also be sensible.
