### PR TITLE
Add support for link custom fields

### DIFF
--- a/net.sf.redmine_mylyn.api/src/net/sf/redmine_mylyn/api/model/CustomField.java
+++ b/net.sf.redmine_mylyn.api/src/net/sf/redmine_mylyn/api/model/CustomField.java
@@ -49,8 +49,10 @@ public class CustomField extends Property implements IQueryField {
 		@XmlEnumValue("version")
 		VERSION,
 		@XmlEnumValue("user")
-		USER;
-		
+		USER,
+		@XmlEnumValue("link")
+		LINK;
+
 		public String getLabel() {
 			return name().toLowerCase();
 		}


### PR DESCRIPTION
We have a link custom field in our Redmine installation, and the plugin is producing a NPE in RedmineUtil#getTaskAttributeType when it tries to retrieve the field format.

We have noticed that the link type is not listed in the CustomField#Format enum type: adding it seems to fix the issue.
