### PR TITLE
DO NOT MERGE: Set Orbit binaries url to one from Juno release

### DIFF
--- a/net.sf.redmine_mylyn.common/META-INF/MANIFEST.MF
+++ b/net.sf.redmine_mylyn.common/META-INF/MANIFEST.MF
@@ -8,7 +8,7 @@ Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Bundle-Activator: net.sf.redmine_mylyn.common.RedmineCommonPlugin
 Export-Package: net.sf.redmine_mylyn.common.logging;x-friends:="net.sf.redmine_mylyn.api,net.sf.redmine_mylyn.core,net.sf.redmine_mylyn.ui"
 Require-Bundle: org.eclipse.core.runtime;bundle-version="3.5.0",
- org.slf4j.api;bundle-version="1.5.11",
+ org.slf4j.api;bundle-version="1.6.1",
  ch.qos.logback.classic;bundle-version="0.9.19",
  ch.qos.logback.core;bundle-version="0.9.19",
  org.eclipse.osgi.services;bundle-version="3.2.0",

--- a/net.sf.redmine_mylyn.feature/feature.xml
+++ b/net.sf.redmine_mylyn.feature/feature.xml
@@ -39,7 +39,7 @@
       <import plugin="org.eclipse.ui.editors" version="3.5.0" match="greaterOrEqual"/>
       <import plugin="org.eclipse.mylyn.commons.ui" version="3.5.0" match="greaterOrEqual"/>
       <import plugin="org.eclipse.jface.text"/>
-      <import plugin="org.slf4j.api" version="1.5.11" match="greaterOrEqual"/>
+      <import plugin="org.slf4j.api" version="1.6.1" match="greaterOrEqual"/>
       <import plugin="ch.qos.logback.classic" version="0.9.19" match="greaterOrEqual"/>
       <import plugin="ch.qos.logback.core" version="0.9.19" match="greaterOrEqual"/>
       <import plugin="org.eclipse.equinox.log" version="1.2.0" match="greaterOrEqual"/>

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<eclipse-site>http://download.eclipse.org/releases/${platform-version-name}</eclipse-site>
 		<mylyn-site>http://download.eclipse.org/mylyn/releases/latest</mylyn-site>
-		<orbit-site>http://download.eclipse.org/tools/orbit/downloads/drops/R20110523182458/repository/</orbit-site>
+		<orbit-site>http://download.eclipse.org/tools/orbit/downloads/drops/R20130118183705/repository/</orbit-site>
 		<aspectj-site>http://download.eclipse.org/tools/ajdt/37/dev/update</aspectj-site>
 	</properties>
 	


### PR DESCRIPTION
THIS PR IS WORK IN PROGRESS.

This Orbit site was created probably during Juno release.
This change is to test if plugin build with this site would
install in Luna.

Other Orbit sites are located here:
http://download.eclipse.org/tools/orbit/downloads/