### PR TITLE
Don't update uncapturedSpentTime, if new elapsed time entry is smalle…

### DIFF
--- a/net.sf.redmine_mylyn.core/src/net/sf/redmine_mylyn/internal/core/RedmineSpentTimeManager.java
+++ b/net.sf.redmine_mylyn.core/src/net/sf/redmine_mylyn/internal/core/RedmineSpentTimeManager.java
@@ -148,7 +148,7 @@ public class RedmineSpentTimeManager implements IRedmineSpentTimeManager {
 		long uncapturedSpentTime  = readLongAttribute(task, UNCAPTURED_SPENT_TIME);
 		
 		if(newElapsedTime < oldElapsedTime) {
-			uncapturedSpentTime = newElapsedTime;
+			return;
 		} else {
 			uncapturedSpentTime += newElapsedTime-oldElapsedTime;
 		}


### PR DESCRIPTION
…r than last saved elapsed time entry.

This pull request relates to issue #81.